### PR TITLE
v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file tracks and describes changes to `example_resources`.
 
 This project adheres to [semantic versioning 2.0][semver].
 
+In progress
+
+- Updates change log to be written in present simple verb tense
+
 v1.0.8 (2016-03-30)
 
 - Adds cookbook version badge
@@ -12,38 +16,38 @@ v1.0.8 (2016-03-30)
 
 v1.0.7 (2016-03-19)
 
-- Add more platform support to test suites
+- Adds more platform support to test suites
 
 v1.0.6 (2016-03-19)
 
-- Add a better translation
+- Adds a better translation
 
 v1.0.5 (2016-03-19)
 
-- Update short description
+- Updates short description
 
 v1.0.4 (2016-03-19)
 
-- Version bump for premature Supermarket upload
+- Bumps version for premature Supermarket upload
 
 v1.0.3 (2016-03-19)
 
-- Update author email
+- Updates author email
 
 v1.0.2 (2016-03-19)
 
-- Improve metadata for Supermarket
-- Increase detail in readme
-- Add license
-- Point to Supermarket instead of GitHub
+- Improves metadata for Supermarket
+- Increases detail in readme
+- Adds license
+- Points to Supermarket instead of GitHub
 
 v1.0.1 (2016-03-18)
 
-- Correct spelling of InSpec
+- Corrects spelling of InSpec
 
 v1.0.0 (2016-03-17)
 
-- Refactor name from `example_resource_cookbook` to `example_resources`
+- Refactors name from `example_resource_cookbook` to `example_resources`
 
 v0.1.0 (2016-03-16)
 


### PR DESCRIPTION
Make supported platform metadata consistent with my other cookbook, [example](https://supermarket.chef.io/cookbooks/example), which depends on this cookbook.
